### PR TITLE
Fix the issue with marking left over

### DIFF
--- a/js/adapt-contrib-textInput.js
+++ b/js/adapt-contrib-textInput.js
@@ -178,6 +178,10 @@ define(function(require) {
         showMarking: function() {
             _.each(this.model.get('_items'), function(item, i) {
                 var $item = this.$('.textinput-item').eq(i);
+                //
+                //remove previous marking
+                $item.removeClass('correct').removeClass('incorrect');
+                //
                 $item.addClass(item._isCorrect ? 'correct' : 'incorrect');
             }, this);
         },


### PR DESCRIPTION
When user will answer incorrectly there are cases when incorrect and correct are displayed at the same time, this patch fixes this.
