### PR TITLE
Fix double spaces after punctuation removed

### DIFF
--- a/js/adapt-contrib-textInput.js
+++ b/js/adapt-contrib-textInput.js
@@ -157,6 +157,8 @@ define(function(require) {
             }
             if (this.model.get('_allowsPunctuation')) {
                 userAnswer = userAnswer.replace(/[\.,-\/#!$£%\^&\*;:{}=\-_`~()]/g, "");
+                //remove any orphan double spaces and replace with single space (B & Q)->(B  Q)->(B Q)
+                userAnswer = userAnswer.replace(/(  +)+/g, " ");
             }
             // removes whitespace from beginning/end (leave any in the middle)
             return $.trim(userAnswer);


### PR DESCRIPTION
When the answer is "City & Guilds Kineo" with _allowsPunctuation will be changed to "City  Guilds Kineo" and user will not know or will try to type double space, user will rather try to answer as: "city guilds kineo" - this fix removes any multiple spaces after removing the punctuation.
